### PR TITLE
What's the point of using Encoding UTF8 in Export-csv?

### DIFF
--- a/Get-MailboxReport.ps1
+++ b/Get-MailboxReport.ps1
@@ -42,6 +42,9 @@ The SMTP address to send the email to.
 
 -MailServer The SMTP server to send the email through.
 
+.PARAMETER Encoding
+Encoding of output file. String is passed to Export-Csv -Encoding parameter so it takes whatever argument that cmdlet takes.
+
 .EXAMPLE
 .\Get-MailboxReport.ps1 -Database DB01
 Returns a report with the mailbox statistics for all mailbox users in
@@ -147,7 +150,10 @@ param(
 	[string]$MailServer,
 
     [Parameter( Mandatory=$false)]
-    [int]$Top = 10
+    [int]$Top = 10,
+
+  [Parameter( Mandatory=$false)]
+  [string]$Encoding = "UTF8"
 
 )
 
@@ -380,7 +386,7 @@ else
 	}
 	else
 	{
-		$report | Export-Csv -Path $reportfile -NoTypeInformation -Encoding UTF8
+		$report | Export-Csv -Path $reportfile -NoTypeInformation -Encoding $Encoding
 		Write-Host -ForegroundColor White "Report written to $reportfile in current path."
 		Get-Item $reportfile
 	}


### PR DESCRIPTION
I'm wondering because it ruins characters on a Swedish system. I had to change it to unicode to preserve characters. 

So if there's no reason to force use of UTF8 I would suggest having an Encoding parameter passed to Export-Csv. 

Edit: To clarify, the broken characters appeared when trying to import the file into Excel, didn't matter which encoding I selected for the import the characters were still broken. Only tried on Microsoft Excel v15 for Macintosh. 
